### PR TITLE
Feat: 사용자 위치 기반 맛집 거리 정렬 기능

### DIFF
--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -2,6 +2,8 @@ import PlaceCard from '@/components/PlaceCard';
 import { useEffect, useState } from 'react';
 import { type PlaceItem } from '@/types';
 import { fetchPlaces } from '@/api/places';
+import { useGeoLocation } from '@/hooks/useGeoLocation';
+import { sortPlacesByDistance } from '@/utils/loc';
 
 type SectionProps = {
   title: string;
@@ -9,6 +11,7 @@ type SectionProps = {
 };
 
 export default function Section({ title, endpoint }: SectionProps) {
+  const { location, error: locError } = useGeoLocation();
   const [list, setList] = useState<PlaceItem[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>('');
@@ -19,7 +22,7 @@ export default function Section({ title, endpoint }: SectionProps) {
         setLoading(true);
         setError('');
         const places = await fetchPlaces({ endpoint });
-        setList(places);
+        setList(sortPlacesByDistance(places, location.lat, location.lon));
       } catch (error: any) {
         setError(error.message);
       } finally {

--- a/src/hooks/useGeoLocation.tsx
+++ b/src/hooks/useGeoLocation.tsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+type Location = {
+  lat: number;
+  lon: number;
+};
+
+export const useGeoLocation = () => {
+  const [location, setLocation] = useState<Location>({ lat: 0, lon: 0 });
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        setLocation({
+          lat: position.coords.latitude,
+          lon: position.coords.longitude,
+        });
+      },
+      error => {
+        setError(error.message);
+      },
+    );
+  }, []);
+
+  return { location, error };
+};

--- a/src/utils/loc.ts
+++ b/src/utils/loc.ts
@@ -1,0 +1,39 @@
+import type { PlaceItem } from '@/types';
+
+function toRad(value: number) {
+  return (value * Math.PI) / 180;
+}
+
+function calculateDistance(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+) {
+  const R = 6371;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lng2 - lng1);
+  const l1 = toRad(lat1);
+  const l2 = toRad(lat2);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(l1) * Math.cos(l2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  const d = R * c;
+  return d;
+}
+
+export function sortPlacesByDistance(
+  places: PlaceItem[],
+  lat: number,
+  lon: number,
+) {
+  const sortedPlaces = [...places];
+  sortedPlaces.sort((a, b) => {
+    const distanceA = calculateDistance(lat, lon, a.lat, a.lon);
+    const distanceB = calculateDistance(lat, lon, b.lat, b.lon);
+    return distanceA - distanceB;
+  });
+  return sortedPlaces;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #15 

## 📝작업 내용

> 사용자의 위치를 받아와 맛집 리스트를 사용자 위치와 가까운 순서대로 정렬
- hooks/useGeoLocation: 사용자 위치 불러오는 커스텀 훅
- utils/loc: 사용자 위치와 가까운 순서로 정렬하는 함수

## 스크린샷 (선택)
### 적용 전)
<img width="1299" height="600" alt="image" src="https://github.com/user-attachments/assets/9d165fae-ac1c-4922-acef-a3b5663df740" />

### 적용 후)
<img width="1293" height="608" alt="image" src="https://github.com/user-attachments/assets/d0f33825-0250-4f7a-ad8c-fc58bd4beb5d" />
